### PR TITLE
Inject some of the base variables into context

### DIFF
--- a/markdownextradata/plugin.py
+++ b/markdownextradata/plugin.py
@@ -3,14 +3,22 @@ from mkdocs.plugins import BasePlugin
 from jinja2 import Template
 
 
+CONFIG_KEYS = [
+    'site_name',
+    'site_author',
+    'site_url',
+    'repo_url',
+    'repo_name'
+]
+
+
 class MarkdownExtraDataPlugin(BasePlugin):
     """
-    Inject config 'extra' variables into the markdown
+    Inject certain config variables into the markdown
     """
     def on_page_markdown(self, markdown, config, **kwargs):
-        if 'extra' not in config:
-            return markdown
-        else:
-            extra = config.get('extra')
-            md_template = Template(markdown)
-            return md_template.render(**extra)
+        context = {key: config.get(key) for key in CONFIG_KEYS if key in config}
+        context.update(config.get('extra', {}))
+        extra = config.get('extra')
+        md_template = Template(markdown)
+        return md_template.render(**extra)


### PR DESCRIPTION
This also always renders the templates with jinja.

This slightly extends the use of the project, as it now opens up the content to the additional powers of jinja (includes, iteration, etc etc), as content is always run through rather than only when the configuration exists, meaning it can be relied upon.