### PR TITLE
allow loading of external data

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,21 @@ Enable the plugin in your `mkdocs.yml`:
 ```yaml
 plugins:
     - search
-    - markdownextradata
+    - markdownextradata:
+        data: path/to/datafiles
 ```
 
 > **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
 
 More information about plugins in the [MkDocs documentation][mkdocs-plugins]
+
+The data path is optional; when absent, it will look for a `_data`
+folder adjacent to your `mkdocs.yml` and inside your `docs_dir`.
+If this path is found, the plugin will read all `.yml` and `.json`
+files inside it and add the data in them to the data available to the templates.
+The paths to these become their variable names, so if inside your data folder you have a file
+called `sections/captions.yml`, the data inside that file will be available in your
+templates as `sections.captions`.
 
 <br/>
 

--- a/markdownextradata/plugin.py
+++ b/markdownextradata/plugin.py
@@ -4,9 +4,8 @@ from jinja2 import Template
 import os
 from pathlib import Path
 import mkdocs
-from ruamel.yaml import YAML
-
-yaml=YAML()
+import yaml
+from itertools import chain
 
 CONFIG_KEYS = [
     'site_name',
@@ -46,15 +45,11 @@ class MarkdownExtraDataPlugin(BasePlugin):
                 if not os.path.exists(data): data = None
 
         if data and os.path.exists(data):
-            for filename in Path(data).glob('**/*.yml'):
+            path = Path(data)
+            for filename in chain(path.glob('**/*.yml'), path.glob('**/*.json')):
                 with open(filename) as f:
                     namespace = os.path.splitext(os.path.relpath(filename, data))[0]
-                    self.__add_data__(config, namespace, yaml.load(f))
-
-            for filename in Path(data).glob('**/*.json'):
-                with open(filename) as f:
-                    namespace = os.path.splitext(os.path.relpath(filename, data))[0]
-                    self.__add_data__(config, namespace, json.load(f))
+                    self.__add_data__(config, namespace, (yaml.load(f) if filename.suffix == '.yml' else json.load(f)))
 
     def on_page_markdown(self, markdown, config, **kwargs):
         context = {key: config.get(key) for key in CONFIG_KEYS if key in config}

--- a/markdownextradata/plugin.py
+++ b/markdownextradata/plugin.py
@@ -1,6 +1,11 @@
 from mkdocs.plugins import BasePlugin
 
 from jinja2 import Template
+from ruamel.yaml import YAML
+yaml=YAML()
+import os
+from pathlib import Path
+import mkdocs
 
 
 CONFIG_KEYS = [
@@ -16,6 +21,41 @@ class MarkdownExtraDataPlugin(BasePlugin):
     """
     Inject certain config variables into the markdown
     """
+
+    config_scheme = (
+        ('data', mkdocs.config.config_options.Type(mkdocs.utils.string_types, default=None)),
+    )
+
+    def __add_data__(self, config, namespace, data):
+        # creates the namespace and adds the data there
+        namespace = ['extra'] + namespace.split(os.sep)
+        holder = config
+        while len(namespace) > 1:
+            if not namespace[0] in holder: holder[namespace[0]] = {}
+            holder = holder[namespace[0]]
+            del namespace[0]
+        holder[namespace[0]] = data
+
+    def on_pre_build(self, config):
+        # this loads all data from the supplied data directory, or otherwise a _data directory next to mkdocs.yml or inside the docs_dir. Does nothing if the dir does not exist.
+
+        data = self.config.get('data')
+        for datadir in [ os.path.dirname(config['config_file_path']), config['docs_dir'] ]:
+            if not data:
+                data = os.path.join(datadir, '_data')
+                if not os.path.exists(data): data = None
+
+        if data and os.path.exists(data):
+            for filename in Path(data).glob('**/*.yml'):
+                with open(filename) as f:
+                    namespace = os.path.splitext(os.path.relpath(filename, data))[0]
+                    self.__add_data__(config, namespace, yaml.load(f))
+
+            for filename in Path(data).glob('**/*.json'):
+                with open(filename) as f:
+                    namespace = os.path.splitext(os.path.relpath(filename, data))[0]
+                    self.__add_data__(config, namespace, json.load(f))
+
     def on_page_markdown(self, markdown, config, **kwargs):
         context = {key: config.get(key) for key in CONFIG_KEYS if key in config}
         context.update(config.get('extra', {}))

--- a/markdownextradata/plugin.py
+++ b/markdownextradata/plugin.py
@@ -1,12 +1,12 @@
 from mkdocs.plugins import BasePlugin
 
 from jinja2 import Template
-from ruamel.yaml import YAML
-yaml=YAML()
 import os
 from pathlib import Path
 import mkdocs
+from ruamel.yaml import YAML
 
+yaml=YAML()
 
 CONFIG_KEYS = [
     'site_name',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     license='MIT',
     python_requires='>=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
-        'mkdocs>=0.17'
+        'mkdocs>=0.17',
+        'ruamel.yaml',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     python_requires='>=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
         'mkdocs>=0.17',
-        'ruamel.yaml',
+        'pyyaml',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This will load yaml/json files from a configurable directory. The main reason I needed it is because I'm migrating away from Jekyll (github pages), where that feature was available.

What does the `context` variable do BTW? I moved loading into `on_pre_build` so it would only be done once, but is `context` doing something special in the `on_page_markdown` phase? I tested this locally and it seemed to work.