### PR TITLE
Fixing YAML and JSON loader warnings

### DIFF
--- a/markdownextradata/plugin.py
+++ b/markdownextradata/plugin.py
@@ -49,7 +49,7 @@ class MarkdownExtraDataPlugin(BasePlugin):
             for filename in chain(path.glob('**/*.yml'), path.glob('**/*.json')):
                 with open(filename) as f:
                     namespace = os.path.splitext(os.path.relpath(filename, data))[0]
-                    self.__add_data__(config, namespace, (yaml.load(f) if filename.suffix == '.yml' else json.load(f)))
+                    self.__add_data__(config, namespace, (yaml.load(f, Loader=yaml.FullLoader) if filename.suffix == '.yml' else json.load(f)))
 
     def on_page_markdown(self, markdown, config, **kwargs):
         context = {key: config.get(key) for key in CONFIG_KEYS if key in config}

--- a/markdownextradata/plugin.py
+++ b/markdownextradata/plugin.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import mkdocs
 import yaml
+import json
 from itertools import chain
 
 CONFIG_KEYS = [


### PR DESCRIPTION
- Ensures the specific Loader to be used to avoid the warning while building with MkDocs.
- Fixing the issues with JSON parse as module was not imported