### PR TITLE
Preprocess during on_page_read_source

### DIFF
--- a/test/docs/index.md
+++ b/test/docs/index.md
@@ -1,3 +1,5 @@
 # Hi there, {{ customer.name }}
 
 Welcome to {{ customer.web_url }}
+
+Inside the included md file there 3 {{ customer.star }}

--- a/test/docs/index.md
+++ b/test/docs/index.md
@@ -1,3 +1,3 @@
-Hi there, {{ customer.name }}
+# Hi there, {{ customer.name }}
 
 Welcome to {{ customer.web_url }}

--- a/test/docs/index.md
+++ b/test/docs/index.md
@@ -2,4 +2,4 @@
 
 Welcome to {{ customer.web_url }}
 
-Inside the included md file there 3 {{ customer.star }}
+Inside the included md file there 3 {{ star }}

--- a/test/mkdocs.yml
+++ b/test/mkdocs.yml
@@ -11,5 +11,6 @@ extra:
   customer:
     name: Your name here
     web_url: www.example.com
+    star: "![star](ressources/star.png)"
   test_json_string: |-
     {"name": "Bob"}

--- a/test/mkdocs.yml
+++ b/test/mkdocs.yml
@@ -8,9 +8,9 @@ plugins:
     - markdownextradata
 
 extra:
+  star: "![star](ressources/star.png)"
   customer:
     name: Your name here
     web_url: www.example.com
-    star: "![star](ressources/star.png)"
   test_json_string: |-
     {"name": "Bob"}

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -22,7 +22,7 @@ def test_basic_working():
         assert index_file.exists(),  f"{index_file} does not exist, it should"
         contents = index_file.read_text()
 
-        assert f"Hi there, {customer.get('name')}" in contents, f"customer.name is not in index"
+        assert '<h1 id="hi-there-your-name-here">Hi there, Your name here</h1>' in contents, f"customer.name is not in index"
         assert f"Welcome to {customer.get('web_url')}" in contents, f"customer.web_url is not in index"
         assert isinstance(test_json_string, str), "test_json_string is not a str it should be"
         assert '{"name": "Bob"}' == test_json_string, f"Json string is not correct"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -23,6 +23,7 @@ def test_basic_working():
         contents = index_file.read_text()
 
         assert '<h1 id="hi-there-your-name-here">Hi there, Your name here</h1>' in contents, f"customer.name is not in index"
+        assert '<p>Inside the included md file there 3 <img alt="star" src="ressources/star.png" /></p></div>' in contents, f"customer.star is not in index or not rendering as expected"
         assert f"Welcome to {customer.get('web_url')}" in contents, f"customer.web_url is not in index"
         assert isinstance(test_json_string, str), "test_json_string is not a str it should be"
         assert '{"name": "Bob"}' == test_json_string, f"Json string is not correct"


### PR DESCRIPTION
Change preprocessor to apply during `on_page_read_source`, not `on_page_markdown`. It uses [the mechanism used by default MkDocs pages](https://github.com/mkdocs/mkdocs/blob/master/mkdocs/structure/pages.py#L114-L121), but passing it through the Jinja preprocessor before return it to the Page object.

Alas, I am not sure how I can test nav generation in with the test framework. If you can give me a pointer or two, I could validate that the nav contains the interpolated string instead of the template var.

Fixes #19 