### PR TITLE
Another attempt at resolving nav/page title issues (see #20)

### DIFF
--- a/test/docs/index.md
+++ b/test/docs/index.md
@@ -1,5 +1,3 @@
-# Hi there, {{ customer.name }}
-
 Welcome to {{ customer.web_url }}
 
 Inside the included md file there 3 {{ star }}

--- a/test/docs/page.md
+++ b/test/docs/page.md
@@ -1,0 +1,1 @@
+# Hi there, {{ customer.name }}

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -22,7 +22,7 @@ def test_basic_working():
         assert index_file.exists(),  f"{index_file} does not exist, it should"
         contents = index_file.read_text()
 
-        assert '<h1 id="hi-there-your-name-here">Hi there, Your name here</h1>' in contents, f"customer.name is not in index"
+        assert '<a href="page/" class="nav-link">Hi there, Your name here</a>' in contents, f"customer.name is not in index"
         assert '<p>Inside the included md file there 3 <img alt="star" src="ressources/star.png" /></p>' in contents, f"customer.star is not in index or not rendering as expected"
         assert f"Welcome to {customer.get('web_url')}" in contents, f"customer.web_url is not in index"
         assert f"{{#binding.path}}" in contents, f"Jinja2 comment syntax wasn't reconfigured via jinja_options as expected"


### PR DESCRIPTION
Hey,

I just found that my previous change was reverted, which came as a surprise since I haven't been (made?) aware of the resulting compatibility issues. Anyhow, this resulted in nav-related issues returning, that I reported back then:

![image](https://user-images.githubusercontent.com/1126941/102495071-ee66d500-4075-11eb-9e06-16be3215ca20.png)

This PR makes another attempt at solving this, by applying Jinja template substitution to both page markdown and titles. You will be able to reproduce the above issue by commenting out `page.title = self.apply_template(page.title)` in `on_page_markdown`.

I also took the liberty to refactor a little and remove (presumably) dead code.