### PR TITLE
Replace mkdocs str_type with native str type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ Thank you for considering to contribute to this project. These guidelines will h
 
 ## Development
 
-#### Setup
+### Setup
 
-##### Prerequisites
+#### Prerequisites
 
 - [Python]
 - [virtualenv]
@@ -33,16 +33,16 @@ pytest
 
 To get changes merged, create a pull request. Here are a few things to pay attention to when doing so: 
 
-#### Commit Messages
+### Commit Messages
 
 The summary of a commit should be concise and worded in an imperative mood.  
 ...a *what* mood? This should clear things up: *[How to Write a Git Commit Message][git-commit-message]*
 
-#### Code Style
+### Code Style
 
 Make sure your code follows [PEP-8](https://www.python.org/dev/peps/pep-0008/) and keeps things consistent with the rest of the code. 
 
-#### Tests
+### Tests
 
 If it makes sense, writing tests for your PRs is always appreciated and will help get them merged.
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
 
 *A MkDocs plugin that injects the mkdocs.yml extra variables into the markdown template*
 
-**usecase**
+## usecase
 
-```
-As a user with variables that need to be inserted at the markdown level, not the template level.
+> As a user with variables that need to be inserted at the markdown level, not the template level.
 I need a mkdocs plugin that will inject my `extras` variables into the markdown template before it gets rendered to html.
-So that I can build my markdown pages with different values for images, urls, client_names, etc. 
-```
+So that I can build my markdown pages with different values for images, urls, client_names, etc.
 
 ## Installation
 
-> **Note:** This package requires MkDocs version 0.17 or higher. 
+> **Note:** This package requires MkDocs version 0.17 or higher.
 
 Install the package with pip:
 
@@ -91,23 +89,23 @@ plugins:
 ```
 
 by default it will search in the folder where your mkdocs.yml is kept
-and in the docs folder for another folder called `_data` 
+and in the docs folder for another folder called `_data`
 (i.e. `./docs/_data/site.yaml`), available as `{{ site.whatever_variable_in_the_yaml}}`.
 
 If these paths are found, the plugin will read all `.yml|.yaml` and `.json`
 files inside them and add the data in them under the `extra` key.
 
-For example, if you have a file called `[path/to/datafiles/]sections/captions.yaml` 
+For example, if you have a file called `[path/to/datafiles/]sections/captions.yaml`
 which includes a variable `foo` - where `[path/to/datafiles/]` is the path declared
 in your configuration under `data` - the data inside that file will be available in
  your templates as `{{sections.captions.foo}}` or `{{sections['captions']['foo']}}`.
 
 Alternatively, you can access all files and variable declared under `data` in template
-using `extra` key. 
+using `extra` key.
 This is particularly useful if your folder or filename do not comply with the Python
 variable naming rules.
 For example, if you have a file `[path/to/datafiles/]1_example/captions.yaml`
-which includes a variable `bar`, writting the template as 
+which includes a variable `bar`, writting the template as
 `{{1_example.captions.bar}}` returns a `jinja2.exceptions.TemplateSyntaxError` since
 the folder `1_example` starts with a number. Instead, you can call this file with
  when the template is `{{extra['1_example']['captions']['bar']}}`.
@@ -129,7 +127,7 @@ you write Markdown that contains Jinja-like syntax that's colliding with the tem
 
 ## Testing
 
-```
+```bash
 virtualenv venv -p python3.7
 source venv/bin/activate
 python setup.py test
@@ -142,9 +140,6 @@ From reporting a bug to submitting a pull request: every contribution is appreci
 Report bugs, ask questions and request features using [Github issues][github-issues].
 If you want to contribute to the code of this project, please read the [Contribution Guidelines][contributing].
 
-[travis-status]: https://travis-ci.org/rosscdh/mkdocs-markdownextradata-plugin.svg?branch=master
-[travis-link]: https://travis-ci.org/rosscdh/mkdocs-markdownextradata-plugin
-[mkdocs-plugins]: http://www.mkdocs.org/user-guide/plugins/
 [github-issues]: https://github.com/rosscdh/mkdocs-markdownextradata-plugin/issues
 [contributing]: CONTRIBUTING.md
 

--- a/markdownextradata/plugin.py
+++ b/markdownextradata/plugin.py
@@ -16,12 +16,6 @@ log.addFilter(warning_filter)
 
 CONFIG_KEYS = ["site_name", "site_author", "site_url", "repo_url", "repo_name"]
 
-if sys.version_info[0] >= 3:
-    str_type = str
-else:
-    str_type = mkdocs.utils.string_types
-
-
 class MarkdownExtraDataPlugin(BasePlugin):
     """
     Inject certain config variables into the markdown
@@ -30,7 +24,7 @@ class MarkdownExtraDataPlugin(BasePlugin):
     JINJA_OPTIONS = "jinja_options"
 
     config_scheme = (
-        ("data", mkdocs.config.config_options.Type(str_type, default=None)),
+        ("data", mkdocs.config.config_options.Type(str, default=None)),
         (JINJA_OPTIONS, mkdocs.config.config_options.Type(dict, default={}))
     )
 


### PR DESCRIPTION
## Purpose

Fixes error when building documentation with mkdocs >= 1.1

`AttributeError: module 'mkdocs.utils' has no attribute 'string_types'`

## Related issues

#40 

## Additional context

https://github.com/comwes/mkpdfs-mkdocs-plugin/pull/15
